### PR TITLE
save all values comma separated instead of only the last one

### DIFF
--- a/gtfparse/attribute_parsing.py
+++ b/gtfparse/attribute_parsing.py
@@ -101,7 +101,10 @@ def expand_attribute_strings(
             value = intern(str(value))
             value_interned_strings[value] = value
 
-        column[i] = value
+        if column[i] == missing_value:
+            column[i] = value
+        else:
+            column[i] = "{},{}".format(column[i], value)
 
     logging.debug(
         "Memory usage after expanding GTF attributes: %0.4f MB" % (


### PR DESCRIPTION
Right now only the last value is returned in the DF if a given attribute key exists more than once in one GTF-line. It doesn't make sense to just return that last value, so I changed the code such that a comma-separeted string is returned for these attributes instead.