### PR TITLE
Update read_csv params to on_bad_lines

### DIFF
--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -86,8 +86,7 @@ def parse_gtf(
         names=REQUIRED_COLUMNS,
         skipinitialspace=True,
         skip_blank_lines=True,
-        error_bad_lines=True,
-        warn_bad_lines=True,
+        on_bad_lines='error',
         chunksize=chunksize,
         engine="c",
         dtype={


### PR DESCRIPTION
Pandas is moving from error_bad_lines and warn_bad_lines to on_bad_lines. Since error_bad_lines was set to True, I think that using on_bad_lines='error' will result in the desired behavior without throwing a FutureWarning each time gtfparse is used.

Other options would be to set on_bad_lines to 'warn', 'skip', or make a custom callback. See https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html#:~:text=bad%20line%20instead.-,on_bad_lines,-%7B%E2%80%98error%E2%80%99%2C%20%E2%80%98warn%E2%80%99%2C%20%E2%80%98skip for more information.