### PR TITLE
switch to pytest

### DIFF
--- a/test/test_ensembl_gtf.py
+++ b/test/test_ensembl_gtf.py
@@ -1,6 +1,5 @@
 from data import data_path
 from gtfparse import read_gtf
-from nose.tools import eq_
 
 ENSEMBL_GTF_PATH = data_path("ensembl_grch37.head.gtf")
 
@@ -18,7 +17,7 @@ EXPECTED_FEATURES = set([
 def test_ensembl_gtf_columns():
     df = read_gtf(ENSEMBL_GTF_PATH)
     features = set(df["feature"])
-    eq_(features, EXPECTED_FEATURES)
+    assert features == EXPECTED_FEATURES
 
 # first 1000 lines of GTF only contained these genes
 EXPECTED_GENE_NAMES = {

--- a/test/test_expand_attributes.py
+++ b/test/test_expand_attributes.py
@@ -1,5 +1,4 @@
 from gtfparse import expand_attribute_strings
-from nose.tools import eq_
 
 def test_attributes_in_quotes():
     attributes = [
@@ -7,10 +6,10 @@ def test_attributes_in_quotes():
         "gene_id \"ENSG002\"; tag \"wolfpuppy\"; version \"2\";"
     ]
     parsed_dict = expand_attribute_strings(attributes)
-    eq_(list(sorted(parsed_dict.keys())), ["gene_id", "tag", "version"])
-    eq_(parsed_dict["gene_id"], ["ENSG001", "ENSG002"])
-    eq_(parsed_dict["tag"], ["bogotron", "wolfpuppy"])
-    eq_(parsed_dict["version"], ["1", "2"])
+    assert list(sorted(parsed_dict.keys())) == ["gene_id", "tag", "version"]
+    assert parsed_dict["gene_id"] == ["ENSG001", "ENSG002"]
+    assert parsed_dict["tag"] == ["bogotron", "wolfpuppy"]
+    assert parsed_dict["version"] == ["1", "2"]
 
 
 def test_attributes_without_quotes():
@@ -19,10 +18,10 @@ def test_attributes_without_quotes():
         "gene_id ENSG002; tag wolfpuppy; version 2"
     ]
     parsed_dict = expand_attribute_strings(attributes)
-    eq_(list(sorted(parsed_dict.keys())), ["gene_id", "tag", "version"])
-    eq_(parsed_dict["gene_id"], ["ENSG001", "ENSG002"])
-    eq_(parsed_dict["tag"], ["bogotron", "wolfpuppy"])
-    eq_(parsed_dict["version"], ["1", "2"])
+    assert list(sorted(parsed_dict.keys())) == ["gene_id", "tag", "version"]
+    assert parsed_dict["gene_id"] == ["ENSG001", "ENSG002"]
+    assert parsed_dict["tag"] == ["bogotron", "wolfpuppy"]
+    assert parsed_dict["version"] == ["1", "2"]
 
 
 def test_optional_attributes():
@@ -32,6 +31,6 @@ def test_optional_attributes():
         "gene_id ENSG003; sometimes-present wolfpuppy;",
     ]
     parsed_dict = expand_attribute_strings(attributes)
-    eq_(list(sorted(parsed_dict.keys())), ["gene_id", "sometimes-present"])
-    eq_(parsed_dict["gene_id"], ["ENSG001", "ENSG002", "ENSG003"])
-    eq_(parsed_dict["sometimes-present"], ["bogotron", "", "wolfpuppy"])
+    assert list(sorted(parsed_dict.keys())) == ["gene_id", "sometimes-present"]
+    assert parsed_dict["gene_id"] == ["ENSG001", "ENSG002", "ENSG003"]
+    assert parsed_dict["sometimes-present"] == ["bogotron", "", "wolfpuppy"]

--- a/test/test_multiple_values_for_tag_attribute.py
+++ b/test/test_multiple_values_for_tag_attribute.py
@@ -1,6 +1,5 @@
 from six import StringIO
 from gtfparse import parse_gtf_and_expand_attributes
-from nose.tools import eq_
 
 # failing example from https://github.com/openvax/gtfparse/issues/2
 GTF_TEXT = (
@@ -15,18 +14,18 @@ GTF_TEXT = (
 def test_parse_tag_attributes():
     parsed = parse_gtf_and_expand_attributes(StringIO(GTF_TEXT))
     tag_column = parsed["tag"]
-    eq_(len(tag_column), 1)
+    assert len(tag_column) == 1
     tags = tag_column[0]
-    eq_(tags, 'cds_end_NF,mRNA_end_NF')
+    assert tags == 'cds_end_NF,mRNA_end_NF'
 
 def test_parse_tag_attributes_with_usecols():
     parsed = parse_gtf_and_expand_attributes(
         StringIO(GTF_TEXT),
         restrict_attribute_columns=["tag"])
     tag_column = parsed["tag"]
-    eq_(len(tag_column), 1)
+    assert len(tag_column) == 1
     tags = tag_column[0]
-    eq_(tags, 'cds_end_NF,mRNA_end_NF')
+    assert tags == 'cds_end_NF,mRNA_end_NF'
 
 def test_parse_tag_attributes_with_usecols_other_column():
     parsed = parse_gtf_and_expand_attributes(

--- a/test/test_parse_gtf_lines.py
+++ b/test/test_parse_gtf_lines.py
@@ -1,5 +1,4 @@
 import numpy as np
-from nose.tools import eq_, assert_raises
 from gtfparse import (
     parse_gtf,
     parse_gtf_and_expand_attributes,
@@ -7,6 +6,7 @@ from gtfparse import (
     ParsingError
 )
 from six import StringIO
+from pytest import raises as assert_raises
 
 gtf_text = """
 # sample GTF data copied from:
@@ -28,27 +28,27 @@ def test_parse_gtf_lines_with_expand_attributes():
         "transcript_source",
     ]
     # convert to list since Py3's dictionary keys are a distinct collection type
-    eq_(list(parsed_dict.keys()), expected_columns)
-    eq_(list(parsed_dict["seqname"]), ["1", "1"])
+    assert list(parsed_dict.keys()) == expected_columns
+    assert list(parsed_dict["seqname"]) == ["1", "1"]
     # convert to list for comparison since numerical columns may be NumPy arrays
-    eq_(list(parsed_dict["start"]), [11869, 11869])
-    eq_(list(parsed_dict["end"]), [14409, 14409])
+    assert list(parsed_dict["start"]) == [11869, 11869]
+    assert list(parsed_dict["end"]) == [14409, 14409]
     # can't compare NaN with equality
     scores = list(parsed_dict["score"])
     assert np.isnan(scores).all(), "Unexpected scores: %s" % scores
-    eq_(list(parsed_dict["gene_id"]), ["ENSG00000223972", "ENSG00000223972"])
-    eq_(list(parsed_dict["transcript_id"]), ["", "ENST00000456328"])
+    assert list(parsed_dict["gene_id"]) == ["ENSG00000223972", "ENSG00000223972"]
+    assert list(parsed_dict["transcript_id"]) == ["", "ENST00000456328"]
 
 
 def test_parse_gtf_lines_without_expand_attributes():
     parsed_dict = parse_gtf(StringIO(gtf_text))
 
     # convert to list since Py3's dictionary keys are a distinct collection type
-    eq_(list(parsed_dict.keys()), REQUIRED_COLUMNS)
-    eq_(list(parsed_dict["seqname"]), ["1", "1"])
+    assert list(parsed_dict.keys()) == REQUIRED_COLUMNS
+    assert list(parsed_dict["seqname"]) == ["1", "1"]
     # convert to list for comparison since numerical columns may be NumPy arrays
-    eq_(list(parsed_dict["start"]), [11869, 11869])
-    eq_(list(parsed_dict["end"]), [14409, 14409])
+    assert list(parsed_dict["start"]) == [11869, 11869]
+    assert list(parsed_dict["end"]) == [14409, 14409]
     # can't compare NaN with equality
     scores = list(parsed_dict["score"])
     assert np.isnan(scores).all(), "Unexpected scores: %s" % scores


### PR DESCRIPTION
Fixes #29 

I have ported all references of nose to use pytest instead. Here's the log of tests run with pytest
```
(debian-sid)[mdb571@debian gtfparse]$ pytest -v

=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.10.5, pytest-7.1.2, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/rmb/packaging/gtfparse-upstream/gtfparse/.hypothesis/examples')
rootdir: /home/rmb/packaging/gtfparse-upstream/gtfparse
plugins: forked-1.4.0, xdist-2.5.0, cov-3.0.0, requests-mock-1.9.3, mock-3.8.2, cython-0.1.1, anyio-3.6.1, benchmark-3.2.2, hypothesis-6.36.0, localserver-0.5.0
collected 20 items

test/test_create_missing_features.py::test_create_missing_features_identity PASSED                                                                                                                           [  5%]
test/test_create_missing_features.py::test_create_missing_features PASSED                                                                                                                                    [ 10%]
test/test_ensembl_gtf.py::test_ensembl_gtf_columns PASSED                                                                                                                                                    [ 15%]
test/test_ensembl_gtf.py::test_ensembl_gtf_gene_names PASSED                                                                                                                                                 [ 20%]
test/test_ensembl_gtf.py::test_ensembl_gtf_gene_names_with_usecols PASSED                                                                                                                                    [ 25%]
test/test_ensembl_gtf.py::test_ensembl_gtf_gene_names_zip PASSED                                                                                                                                             [ 30%]
test/test_ensembl_gtf.py::test_ensembl_gtf_gene_names_with_usecols_gzip PASSED                                                                                                                               [ 35%]
test/test_expand_attributes.py::test_attributes_in_quotes PASSED                                                                                                                                             [ 40%]
test/test_expand_attributes.py::test_attributes_without_quotes PASSED                                                                                                                                        [ 45%]
test/test_expand_attributes.py::test_optional_attributes PASSED                                                                                                                                              [ 50%]
test/test_multiple_values_for_tag_attribute.py::test_parse_tag_attributes PASSED                                                                                                                             [ 55%]
test/test_multiple_values_for_tag_attribute.py::test_parse_tag_attributes_with_usecols PASSED                                                                                                                [ 60%]
test/test_multiple_values_for_tag_attribute.py::test_parse_tag_attributes_with_usecols_other_column PASSED                                                                                                   [ 65%]
test/test_parse_gtf_lines.py::test_parse_gtf_lines_with_expand_attributes PASSED                                                                                                                             [ 70%]
test/test_parse_gtf_lines.py::test_parse_gtf_lines_without_expand_attributes PASSED                                                                                                                          [ 75%]
test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_many_fields PASSED                                                                                                                              [ 80%]
test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_few_fields PASSED                                                                                                                               [ 85%]
test/test_read_stringtie_gtf.py::test_read_stringtie_gtf_as_dataframe PASSED                                                                                                                                 [ 90%]
test/test_read_stringtie_gtf.py::test_read_stringtie_gtf_as_dataframe_float_values PASSED                                                                                                                    [ 95%]
test/test_refseq_gtf.py::test_read_refseq_gtf_as_dataframe PASSED                                                                                                                                            [100%]
================================================================================================= warnings summary =================================================================================================
../../../../../usr/lib/python3/dist-packages/gtfparse/read_gtf.py:151: 1 warning
test/test_ensembl_gtf.py: 5 warnings
test/test_multiple_values_for_tag_attribute.py: 3 warnings
test/test_parse_gtf_lines.py: 1 warning
test/test_read_stringtie_gtf.py: 2 warnings
test/test_refseq_gtf.py: 1 warning
  /usr/lib/python3/dist-packages/gtfparse/read_gtf.py:151: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version.


    result = parse_gtf(

../../../../../usr/lib/python3/dist-packages/gtfparse/read_gtf.py:151: 1 warning
test/test_ensembl_gtf.py: 5 warnings
test/test_multiple_values_for_tag_attribute.py: 3 warnings
test/test_parse_gtf_lines.py: 1 warning
test/test_read_stringtie_gtf.py: 2 warnings
test/test_refseq_gtf.py: 1 warning
  /usr/lib/python3/dist-packages/gtfparse/read_gtf.py:151: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version.


    result = parse_gtf(

test/test_parse_gtf_lines.py::test_parse_gtf_lines_without_expand_attributes
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:44: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version.


    parsed_dict = parse_gtf(StringIO(gtf_text))

test/test_parse_gtf_lines.py::test_parse_gtf_lines_without_expand_attributes
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:44: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version.


    parsed_dict = parse_gtf(StringIO(gtf_text))

test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_many_fields
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:61: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version.


    parse_gtf(StringIO(bad_gtf_text))

test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_many_fields
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:61: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version.


    parse_gtf(StringIO(bad_gtf_text))

test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_few_fields
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:67: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version.


    parse_gtf(StringIO(bad_gtf_text))

test/test_parse_gtf_lines.py::test_parse_gtf_lines_error_too_few_fields
  /home/rmb/packaging/gtfparse-upstream/gtfparse/test/test_parse_gtf_lines.py:67: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version.


    parse_gtf(StringIO(bad_gtf_text))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

========================================================================================= 20 passed, 32 warnings in 1.06s ==========================================================================================

```