### PR TITLE
'sep' argument for polar.scan_csv has been renamed to 'seperator'.

### DIFF
--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -87,7 +87,7 @@ def parse_with_polars_lazy(
     polars.toggle_string_cache(True)
     kwargs = dict(
         has_header=False,
-        sep="\t",
+        separator="\t",
         comment_char="#",
         null_values=".",
         dtypes={


### PR DESCRIPTION
@iskandr or @timodonnell  The "sep" argument has been renamed to "seperator" in polars 0.16.14, making gtfparse only compatible with earlier versions from polars. This PR should fix this issue.

See https://github.com/pola-rs/polars/pull/7533