### PR TITLE
Fix Coveralls race: upload coverage from one Python version only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,5 @@ jobs:
         run: |
           ./test.sh
       - name: Publish coverage to Coveralls
+        if: matrix.python-version == '3.11'
         uses: coverallsapp/github-action@v2.2.3


### PR DESCRIPTION
## Summary
Restricts the coverage upload step in `.github/workflows/tests.yml` to run only on the 3.11 matrix job (`if: matrix.python-version == '3.11'`).

Previously every matrix job (3.9, 3.10, 3.11) uploaded coverage to Coveralls. Whichever finished first closed the build, and the others failed with:

> Can't add a job to a build that is already closed. Build <id> is closed. See docs.coveralls.io/parallel-builds

This was a pre-existing flake — lint and tests were passing on all versions. Same pattern as the sibling `mhcgnomes` repo.

## Test plan
- [ ] CI on this PR is green (3.9 + 3.10 + 3.11 pass, coverage uploads once from 3.11)