### PR TITLE
Fix #70: stop calling logging.basicConfig() at import time

### DIFF
--- a/gtfparse/__init__.py
+++ b/gtfparse/__init__.py
@@ -23,7 +23,7 @@ from .read_gtf import (
     read_gtf,
 )
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 __all__ = [
     "GENCODE_BIOTYPE_ALIASES",

--- a/gtfparse/attribute_parsing.py
+++ b/gtfparse/attribute_parsing.py
@@ -14,7 +14,6 @@ import logging
 from collections import OrderedDict
 from sys import intern
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -103,5 +102,5 @@ def expand_attribute_strings(attribute_strings, quote_char="'", missing_value=""
                 extra_columns[column_name] = column
                 column_order.append(column_name)
 
-    logging.info("Extracted GTF attributes: %s" % column_order)
+    logger.info("Extracted GTF attributes: %s" % column_order)
     return OrderedDict((column_name, extra_columns[column_name]) for column_name in column_order)

--- a/gtfparse/attribute_parsing.py
+++ b/gtfparse/attribute_parsing.py
@@ -102,5 +102,5 @@ def expand_attribute_strings(attribute_strings, quote_char="'", missing_value=""
                 extra_columns[column_name] = column
                 column_order.append(column_name)
 
-    logger.info("Extracted GTF attributes: %s" % column_order)
+    logger.info("Extracted GTF attributes: %s", column_order)
     return OrderedDict((column_name, extra_columns[column_name]) for column_name in column_order)

--- a/gtfparse/create_missing_features.py
+++ b/gtfparse/create_missing_features.py
@@ -15,7 +15,6 @@ from collections import OrderedDict
 
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -58,9 +57,9 @@ def create_missing_features(dataframe, unique_keys={}, extra_columns={}, missing
 
     for feature_name, groupby_key in unique_keys.items():
         if feature_name in existing_features:
-            logging.info("Feature '%s' already exists in GTF data" % feature_name)
+            logger.info("Feature '%s' already exists in GTF data" % feature_name)
             continue
-        logging.info("Creating rows for missing feature '%s'" % feature_name)
+        logger.info("Creating rows for missing feature '%s'" % feature_name)
 
         # don't include rows where the groupby key was missing
         missing = pd.Series([x is None or x == "" for x in dataframe[groupby_key]])

--- a/gtfparse/create_missing_features.py
+++ b/gtfparse/create_missing_features.py
@@ -57,9 +57,9 @@ def create_missing_features(dataframe, unique_keys={}, extra_columns={}, missing
 
     for feature_name, groupby_key in unique_keys.items():
         if feature_name in existing_features:
-            logger.info("Feature '%s' already exists in GTF data" % feature_name)
+            logger.info("Feature '%s' already exists in GTF data", feature_name)
             continue
-        logger.info("Creating rows for missing feature '%s'" % feature_name)
+        logger.info("Creating rows for missing feature '%s'", feature_name)
 
         # don't include rows where the groupby key was missing
         missing = pd.Series([x is None or x == "" for x in dataframe[groupby_key]])

--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -19,7 +19,6 @@ import polars
 from .attribute_parsing import expand_attribute_strings
 from .parsing_error import ParsingError
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -406,10 +405,10 @@ def read_gtf(
             # the 2nd column is the transcript_biotype (otherwise, it's the
             # gene_biotype)
             if "gene_biotype" not in column_names:
-                logging.info("Using column 'source' to replace missing 'gene_biotype'")
+                logger.info("Using column 'source' to replace missing 'gene_biotype'")
                 result_df["gene_biotype"] = result_df["source"]
             if "transcript_biotype" not in column_names:
-                logging.info("Using column 'source' to replace missing 'transcript_biotype'")
+                logger.info("Using column 'source' to replace missing 'transcript_biotype'")
                 result_df["transcript_biotype"] = result_df["source"]
 
     if usecols is not None:


### PR DESCRIPTION
## Problem

Fixes #70. gtfparse called `logging.basicConfig(level=logging.INFO)` at **module import time** in three modules:

- `gtfparse/read_gtf.py`
- `gtfparse/attribute_parsing.py`
- `gtfparse/create_missing_features.py`

For a library this is a well-known anti-pattern. `basicConfig()` configures the **root** logger on behalf of whatever application imports us — it attaches a `StreamHandler` and forces the level to `INFO`. Simply `import gtfparse` therefore hijacks the host application's logging setup (its handlers/level get overridden by whichever module happens to import first).

## Fix

- Remove all three `logging.basicConfig(level=logging.INFO)` calls.
- Route the remaining log statements through the module-level `logger` (`logging.getLogger(__name__)`) instead of the root-logger convenience functions (`logging.info(...)`), which would otherwise *implicitly* re-trigger `basicConfig()` on first use.

Configuring handlers and levels is now left entirely to the application, per the [stdlib logging guidance for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library). The library only emits records through its named loggers.

## Verification

- New behavior check: `import gtfparse` no longer adds handlers to or changes the level of the root logger, and the package's named loggers stay at `NOTSET`.
- Full test suite passes (59 passed), including the `caplog`-based log-capture tests in `tests/test_gencode_gtf.py`.
- `ruff check` and `ruff format --check` clean.

https://claude.ai/code/session_014fNxSBm5zvdsDNwN3nhmpS