### PR TITLE
Fix #70: don't call logging.basicConfig() at import

### DIFF
--- a/gtfparse/__init__.py
+++ b/gtfparse/__init__.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from .attribute_parsing import expand_attribute_strings
 from .create_missing_features import create_missing_features
 from .parsing_error import ParsingError
@@ -22,6 +24,12 @@ from .read_gtf import (
     parse_gtf_pandas,
     read_gtf,
 )
+
+# Per the Python logging HOWTO ("Configuring Logging for a Library"), attach a
+# no-op handler to the package logger so that importing gtfparse neither emits
+# log output nor reconfigures the root logger; applications opt in to gtfparse
+# logs through their own logging configuration.
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __version__ = "2.7.1"
 

--- a/gtfparse/attribute_parsing.py
+++ b/gtfparse/attribute_parsing.py
@@ -14,7 +14,6 @@ import logging
 from collections import OrderedDict
 from sys import intern
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/gtfparse/create_missing_features.py
+++ b/gtfparse/create_missing_features.py
@@ -15,7 +15,6 @@ from collections import OrderedDict
 
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -19,7 +19,6 @@ import polars
 from .attribute_parsing import expand_attribute_strings
 from .parsing_error import ParsingError
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Fixes #70.

`attribute_parsing.py`, `create_missing_features.py`, and `read_gtf.py` each call `logging.basicConfig(level=logging.INFO)` at module import. That mutates the **root** logger (adds a handler, sets the root level to `INFO`) as an import side effect, which hijacks a downstream application's logging configuration and breaks `pytest`'s `caplog` in downstream test suites.

## Change
Per the Python logging HOWTO (*"Configuring Logging for a Library"*):
- Remove the three import-time `logging.basicConfig(...)` calls (keep each module's `logger = logging.getLogger(__name__)`).
- Attach a `logging.NullHandler()` to the top-level `gtfparse` logger in `__init__.py`, so importing gtfparse emits nothing and reconfigures nothing by default. Applications opt in to gtfparse's INFO logs via their own logging config.

## Before / after
```python
import logging; import gtfparse
print(logging.getLogger().handlers, logging.getLogger().level)
# before: [<StreamHandler <stderr> (NOTSET)>] 20   (root hijacked, level INFO)
# after : []                                    30   (untouched, default WARNING)
```

## Tests
Full suite green (59 passed). No behavior change beyond logging side effects.